### PR TITLE
[Transactions] Add balance transfer functionality

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -78,6 +78,7 @@ fn main() {
       demo_tx,
       create_user_account,
       wallet_type,
+      balance_transfer,
       //Tower
       miner_once,
       start_backlog_sender_listener,

--- a/src/components/txs/BalanceTransfer.svelte
+++ b/src/components/txs/BalanceTransfer.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+    import { invoke } from "@tauri-apps/api/tauri";
+    import { responses } from "../../debug";
+    import UIkit from "uikit";
+    import { notify_success } from "../../carpeNotify";
+    import { raise_error } from "../../carpeError";
+
+    let destinationAddress = ""
+    let transferAmount
+    let isWaiting = false
+    let isTransferInputValid
+
+    $: isTransferInputValid = (destinationAddress.length == 32) && (Number(transferAmount) > 0)
+
+    function balanceTransfer() {
+        isWaiting = true
+        invoke("balance_transfer", {
+            address: destinationAddress,
+            coins: transferAmount
+        })
+            .then((res: string) => {
+                responses.set(res);
+                notify_success("Tx successfully");
+                isWaiting = false
+            })
+            .catch(e => {
+                raise_error(e, false, "balanceTransfer");
+                isWaiting = false
+            })
+    }
+    function openTransferForm() {
+        UIkit.modal("#balance-transfer-modal").show()
+    }
+</script>
+
+<main>
+    <div>
+        <button class="uk-button uk-button-default" on:click={openTransferForm}> BALANCE TRANSFER </button>
+    </div>
+    <div id="balance-transfer-modal">
+        <div class="uk-modal-dialog uk-modal-body">
+            <form id="transfer-form">
+                <fieldset class="uk-fieldset">
+                    <div class="uk-margin uk-inline-block uk-width-1-1">
+                        <span> Destination address</span>
+                        <input
+                                class="uk-input"
+                                type="text"
+                                bind:value={destinationAddress}
+                        />
+                    </div>
+                    <div class="uk-margin uk-inline-block uk-width-1-1">
+                        <span> Amount </span>
+                        <input
+                                class="uk-input"
+                                type="number"
+                                bind:value={transferAmount}
+                        />
+                    </div>
+                    <div>
+                        <button
+                                class="uk-button uk-button-primary uk-align-right"
+                                type="button"
+                                disabled={isWaiting || !isTransferInputValid}
+                                on:click|preventDefault={balanceTransfer}
+                        >
+                            {#if isWaiting}
+                                Awaiting Tx
+                            {:else}
+                                Transfer
+                            {/if}
+                        </button>
+                        <button
+                                class="uk-button uk-button-default uk-align-right uk-modal-close"
+                                type="button"
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                </fieldset>
+            </form>
+        </div>
+    </div>
+</main>

--- a/src/components/txs/Transactions.svelte
+++ b/src/components/txs/Transactions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import Onboard from "./Onboard.svelte";
-
+import BalanceTransfer from "./BalanceTransfer.svelte";
 
 </script>
 
@@ -10,4 +10,5 @@ import Onboard from "./Onboard.svelte";
   </div>
   
   <Onboard/>
+  <BalanceTransfer/>
 </main>


### PR DESCRIPTION
## Motivation

**This PR adds the ability to transfer coins between accounts**

Link to mission: [Carpe: Transfers between Accounts](https://airtable.com/shrCuXWvrZgHkspk7/tblixhNzkEaKt3a75/viwlz7S2kmgCkoHFS/recqJXVRaZOScSuFT)

## Related PRs

[[txs] change balance_transfer API for Carpe app #995](https://github.com/OLSF/libra/pull/995)

___

Parameter:
  - Destination address: string of 32 hexadecimal digits representing the destination address of the transaction
  - Amount: positive integer representing the number of coins the user want to transfer

<img width="982" alt="image" src="https://user-images.githubusercontent.com/20924562/153838820-87e2e619-c1e6-4452-ac38-f6c6ec29cc6c.png">
<img width="998" alt="image" src="https://user-images.githubusercontent.com/20924562/153838923-a8a209ac-406d-4d57-940f-06e05d1dec43.png">
