### PR TITLE
[DRAFT] feat: show unlocked balance for wallets

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5150,7 +5150,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
- "nix 0.22.2",
+ "nix 0.18.0",
  "num-format",
  "ol-keys",
  "ol-types",

--- a/src-tauri/src/commands/query.rs
+++ b/src-tauri/src/commands/query.rs
@@ -53,6 +53,15 @@ pub fn get_balance(account: AccountAddress) -> Result<u64, CarpeError> {
     .map_err(|_| CarpeError::misc(&format!("Could not get balance from account: {}", account)))
 }
 
+pub fn get_unlocked_balance(account: AccountAddress) -> Result<u64, CarpeError> {
+  dbg!("get_unlocked_balance");
+  let mut node = get_node_obj()?;
+  let bal = node.query(QueryType::UnlockedBalance { account })?;
+  bal
+    .parse::<u64>()
+    .map_err(|_| CarpeError::misc(&format!("Could not get unlocked balance from account: {}", account)))
+}
+
 #[tauri::command(async)]
 pub async fn get_recovery_mode() -> Result<u64, CarpeError> {
   let mut node = get_node_obj()?;

--- a/src-tauri/src/commands/wallets.rs
+++ b/src-tauri/src/commands/wallets.rs
@@ -18,7 +18,7 @@ use ol_keys::wallet;
 use std::fs::{self, create_dir_all, File};
 use std::io::prelude::*;
 
-use super::get_balance;
+use super::{get_unlocked_balance, get_balance};
 use super::get_payment_events;
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct Accounts {
@@ -32,6 +32,7 @@ pub struct AccountEntry {
   pub nickname: String,
   pub on_chain: Option<bool>,
   pub balance: Option<u64>,
+  pub unlocked_balance: Option<u64>,
 }
 
 impl AccountEntry {
@@ -42,6 +43,7 @@ impl AccountEntry {
       nickname: get_short(address),
       on_chain: None,
       balance: None,
+      unlocked_balance: None,
     }
   }
 }
@@ -135,6 +137,8 @@ fn map_get_balance(mut all_accounts: Accounts) -> Result<Accounts, CarpeError> {
     .into_iter()
     .map(|mut e| {
       e.balance = get_balance(e.account).ok();
+      e.unlocked_balance = get_unlocked_balance(e.account).ok();
+      if e.unlocked_balance.is_none() { e.unlocked_balance = e.balance};
       e.on_chain = Some(e.balance.is_some());
       e
     })
@@ -203,6 +207,7 @@ fn insert_account_db(
     nickname: nickname,
     on_chain: None,
     balance: None,
+    unlocked_balance: None,
   };
 
   if !all.accounts.contains(&new_account) {

--- a/src/accountActions.ts
+++ b/src/accountActions.ts
@@ -4,7 +4,7 @@ import { raise_error } from './carpeError';
 import { responses } from './debug';
 import { minerLoopEnabled, tower} from "./miner";
 import { notify_success, notify_error } from './carpeNotify';
-import { AccountEntry, all_accounts, isInit, isRefreshingAccounts, mnem, signingAccount, accountEvents, isAccountsLoaded, makeWhole } from './accounts';
+import { AccountEntry, all_accounts, isInit, isRefreshingAccounts, mnem, signingAccount, accountEvents, isAccountsLoaded, makeWhole, showUnlockedBalance } from './accounts';
 
 export const loadAccounts = async () => { 
   // fetch data from local DB
@@ -55,6 +55,13 @@ export function tryRefreshSignerAccount(newData: AccountEntry) {
   }
 }
 
+export function toggleLockedBalance(){
+  if(get(showUnlockedBalance)){
+    showUnlockedBalance.set(false);
+  }else{
+    showUnlockedBalance.set(true);
+  }
+}
 
 export const isCarpeInit = async () => {
   invoke("is_init", {})

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -6,6 +6,7 @@ export interface AccountEntry {
   nickname: string,
   on_chain: any, // null or bool
   balance: any, // null or number
+  unlocked_balance: any, // null or number
 }
 
 export const new_account = function (account: string, authkey: string, nickname: string): AccountEntry {
@@ -16,6 +17,7 @@ export const new_account = function (account: string, authkey: string, nickname:
     nickname: nickname,
     on_chain: null,
     balance: null,
+    unlocked_balance: null,
   }
 };
 

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -26,4 +26,5 @@ export const isRefreshingAccounts = writable(false);
 export const all_accounts = writable<AccountEntry[]>([]);
 export const isAccountsLoaded = writable(false);
 export const accountEvents = writable({}); // TODO define interface AccountEvent
+export const showUnlockedBalance = writable(false);
 export const makeWhole = writable({});

--- a/src/components/wallet/AccountsList.svelte
+++ b/src/components/wallet/AccountsList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
-  import { setAccount } from "../../accountActions";
+  import { setAccount, toggleLockedBalance } from "../../accountActions";
   import type { AccountEntry } from "../../accounts";
   import IconMining from "../icons/IconMining.svelte";
   import UIkit from "uikit";
@@ -11,6 +11,7 @@
 
   export let my_account: AccountEntry;
   export let accountList: AccountEntry[];
+  export let showingUnlockedBalance: boolean;
   export let isMining: boolean;
   export let isConnected: boolean;
 
@@ -27,7 +28,7 @@
           <th>{$_("wallet.account_list.nickname")}</th>
           <th>{$_("wallet.account_list.address")}</th>
           <th>{$_("wallet.account_list.authkey")}</th>
-          <th class="uk-text-right">{$_("wallet.account_list.balance")}</th>
+          <th class="uk-text-right">{$_("wallet.account_list.balance")} <button on:click|preventDefault={toggleLockedBalance} uk-icon={showingUnlockedBalance ? "lock" : "unlock"} title={showingUnlockedBalance ? "Show unlocked balance" : "Show total balance"}></button></th>
         </tr>
       </thead>
       <tbody>
@@ -68,7 +69,7 @@
                     </div>
                   {/if}
 
-                  {printCoins(a.balance)}
+                  {showingUnlockedBalance ? printCoins(a.balance): 'unlocked placeholder'}
                 </div>
               {:else if a.balance == null}
                 {$_("wallet.account_list.loading")}...

--- a/src/components/wallet/AccountsList.svelte
+++ b/src/components/wallet/AccountsList.svelte
@@ -69,7 +69,7 @@
                     </div>
                   {/if}
 
-                  {showingUnlockedBalance ? printCoins(a.balance): 'unlocked placeholder'}
+                  {showingUnlockedBalance ? printCoins(a.balance): printCoins(a.unlocked_balance)}
                 </div>
               {:else if a.balance == null}
                 {$_("wallet.account_list.loading")}...

--- a/src/components/wallet/Wallet.svelte
+++ b/src/components/wallet/Wallet.svelte
@@ -10,6 +10,7 @@
   } from "../../accounts";
   import { routes } from "../../routes";
   import type { AccountEntry } from "../../accounts";
+  import { showUnlockedBalance } from "../../accounts";
   import Newbie from "./Newbie.svelte";
   import AccountsList from "./AccountsList.svelte";
   import ReminderCreate from "./ReminderCreate.svelte";
@@ -24,6 +25,7 @@
   let my_account: AccountEntry;
   let accountList: AccountEntry[] = null;
   let pendingAccounts: AccountEntry[] = [];
+  let showingUnlockedBalance = false;
   let isMining = false;
   let isRefreshing: boolean = true;
   let isConnected: boolean = true;
@@ -32,6 +34,7 @@
   let unsubsConnected;
   let unsubsAll_accounts;
   let unsubsSigningAccount;
+  let unsubsShowUnlockedBalance;
   let unsubsIsAccountsLoaded;
   let unsubsMinerLoopEnabled;
   let unsubsIsRefreshingAccounts;
@@ -43,6 +46,7 @@
       pendingAccounts = all.filter(x => !x.on_chain);
     });
     unsubsSigningAccount = signingAccount.subscribe(a => my_account = a);
+    unsubsShowUnlockedBalance = showUnlockedBalance.subscribe(boo => showingUnlockedBalance = boo);
     unsubsIsAccountsLoaded = isAccountsLoaded.subscribe(boo => isLoaded = boo);
     unsubsMinerLoopEnabled = minerLoopEnabled.subscribe(boo => isMining = boo);
     unsubsIsRefreshingAccounts = isRefreshingAccounts.subscribe(boo => isRefreshing = boo);   
@@ -52,6 +56,7 @@
     unsubsConnected && unsubsConnected();
     unsubsAll_accounts && unsubsAll_accounts();
     unsubsSigningAccount && unsubsSigningAccount();
+    unsubsShowUnlockedBalance && unsubsShowUnlockedBalance();
     unsubsIsAccountsLoaded && unsubsIsAccountsLoaded();
     unsubsMinerLoopEnabled && unsubsMinerLoopEnabled();
     unsubsIsRefreshingAccounts && unsubsIsRefreshingAccounts();
@@ -77,7 +82,7 @@
           <h2 class="uk-text-light uk-text-muted uk-text-uppercase">{$_("wallet.wallet")}</h2>
         </div>
         
-        <AccountsList {my_account} {accountList} {isMining} {isConnected} />
+        <AccountsList {my_account} {accountList} {showingUnlockedBalance} {isMining} {isConnected} />
 
         <ReminderCreate {pendingAccounts} {isConnected} />
 


### PR DESCRIPTION
## Description

Allow users to see their unlocked balance by toggling a lock icon beside the balance header.


## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [X] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

- This feature relies on PR [1110](https://github.com/OLSF/libra/pull/1110) within the libra repo being merged.

## Testing

- Needs further testing once dependent PR's are merged

## Screenshots (if applicable)

![Screen Shot 2022-05-15 at 3 08 08 PM](https://user-images.githubusercontent.com/97761083/168496221-52af8185-ec05-492e-9554-afad5fe08c03.png)


![Screen Shot 2022-05-15 at 3 08 35 PM](https://user-images.githubusercontent.com/97761083/168496419-4c1daaca-bb27-4680-b069-f00662b779f0.png)
