### PR TITLE
Fix refresh_upstream_peer_stats

### DIFF
--- a/src-tauri/src/commands/preferences.rs
+++ b/src-tauri/src/commands/preferences.rs
@@ -58,9 +58,9 @@ pub fn debug_preferences_path() -> Result<PathBuf, CarpeError> {
 /// refreshes statistics and returns the synced peers
 pub async fn refresh_upstream_peer_stats() -> Result<Vec<Url>, CarpeError> {
   let mut app_cfg = get_cfg()?;
-  app_cfg.refresh_network_profile_and_save(None).await?; // uses app_cfg.chain_info_chain_id
-  let np = app_cfg.get_network_profile(None)?;
-  // dbg!(&np);
+  
+  let np = app_cfg.refresh_network_profile_and_save(None).await?; // uses app_cfg.chain_info_chain_id
+  app_cfg.network_playlist = vec![np.clone()];
   app_cfg.save_file()?;
 
   let peers = match np.the_good_ones() {

--- a/src/modules/accountActions.ts
+++ b/src/modules/accountActions.ts
@@ -102,7 +102,6 @@ export const refreshAccounts = async () => {
           )
         })
         if (changedCurrentAccount) {
-          console.log('ref::::')
           signingAccount.set(changedCurrentAccount)
         }
       }

--- a/src/modules/networks.ts
+++ b/src/modules/networks.ts
@@ -158,10 +158,6 @@ export const incrementBackoff = () => {
   scanning_fullnodes_backoff.set(new_time.getSeconds())
 }
 
-let current_network_profile: NetworkPlaylist = defaultPlaylist()
-network_profile.subscribe((value) => {
-  current_network_profile = value
-})
 let isTest = false
 nodeEnvIsTest.subscribe((value) => {
   isTest = value
@@ -170,9 +166,8 @@ export const initNetwork = async () => {
   logger(Level.Info, 'initNetwork')
   if (!isTest) {
     await getNetwork()
-    if (current_network_profile.chain_id === NamedChain.TESTING) {
-      return await updateNetwork(playlistJsonUrl, false)
-    }
+
+    return await updateNetwork(playlistJsonUrl, false)
   }
   return true
 }

--- a/src/modules/tick.ts
+++ b/src/modules/tick.ts
@@ -1,7 +1,7 @@
 import { get } from 'svelte/store'
 import { getAccounts, refreshAccounts } from './accountActions'
 // import { getLocalHeight, getTowerChainView, maybeEmitBacklog } from './miner_invoke'
-import { getMetadata } from './networks'
+import { getMetadata, refreshUpstreamPeerStats } from './networks'
 import { isInit } from './accounts'
 import { Level, logger } from './carpeError'
 
@@ -21,7 +21,8 @@ export const carpeTick = async () => {
       tick_in_progress = true
 
       // don't try to connect while we are booting up the app and looking for fullnodes
-      // things that need network connectivity e.g. miner happen here
+
+      await refreshUpstreamPeerStats()
       getMetadata()
         .then(refreshAccounts)
         // tower things


### PR DESCRIPTION
The data obtained by refresh_upstream_peer_stats is not saved in the config.yaml file.