### PR TITLE
feat: add column sorting feature to accounts table

### DIFF
--- a/src/components/wallet/Wallet.svelte
+++ b/src/components/wallet/Wallet.svelte
@@ -27,7 +27,9 @@
           {$_('wallet.wallet')}
         </h2>
       </div>
-      <div class="uk-position-right uk-text-light uk-text-uppercase uk-flex-inline uk-flex-column">
+      <div
+        class="uk-position-right uk-text-light uk-text-uppercase uk-flex-inline uk-flex-column max-height-fit-content"
+      >
         <span class="uk-margin-small-bottom"
           >{$_('wallet.account_list.balance')}: {printCoins($totalBalance.total)}</span
         >
@@ -42,3 +44,10 @@
     </div>
   {/if}
 </main>
+
+<style>
+  .max-height-fit-content {
+    max-height: -webkit-fit-content;
+    max-height: fit-content; /* Standard syntax for other browsers */
+  }
+</style>


### PR DESCRIPTION
# Feature: Account Sorting in Table

This feature enables users to organize accounts displayed in a table based on:
- Address
- Unlocked
- Balance

Users can sort each category in both ascending and descending order, allowing them to view the most pertinent data according to their needs.

## Additional Details:

 - Arrow Indicator: The sorting arrow icon appears in the column header only after a user clicks on it, indicating the current sort direction.
 - Default Sorting: Initially, accounts are displayed in the order they were added by the user.

This structure ensures flexibility and clarity, facilitating efficient data management.