### PR TITLE
Disable Watch-Only Accounts from Transfer Screen

### DIFF
--- a/src-tauri/src/commands/wallets.rs
+++ b/src-tauri/src/commands/wallets.rs
@@ -317,7 +317,7 @@ pub async fn switch_profile(account: AccountAddress) -> Result<CarpeProfile, Car
   app_cfg.save_file()?;
   
   // TODO: gross, fix upstream `app_cfg.rs` to prevent the borrow issues here 
-  let mut profile = app_cfg.get_profile(Some(account.to_string()))?;
+  let profile = app_cfg.get_profile(Some(account.to_string()))?;
 
   // Assign account note
   let mut profiles: Vec<CarpeProfile> = vec![profile.into()];

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -20,6 +20,8 @@
   ]
 
   const location_store = useLocation()
+
+  $: watchOnly = $signingAccount?.watch_only
 </script>
 
 <main class="uk-margin-top">
@@ -36,20 +38,12 @@
           <li class="uk-padding {$location_store.pathname.includes('wallet') ? 'uk-active' : ''}">
             <Link to={routes.wallet}>{$_('nav.wallet')}</Link>
           </li>
-          <!-- <li class="uk-padding {$location_store.pathname.includes('miner') ? 'uk-active' : ''}">
-          <Link to={routes.miner}>{$_('nav.miner')}</Link>
-        </li> -->
           <li class="uk-padding {$location_store.pathname.includes('transfer') ? 'uk-active' : ''}">
-            <Link to={routes.transfer}>{$_('nav.transactions')}</Link>
+            <Link to={watchOnly ? routes.wallet : routes.transfer}>{$_('nav.transactions')}</Link>
           </li>
-          <!-- Remove Events tab till we get a fullnode set able to respond to these queries -->
-          <!-- <li><Link to={routes.events}>{$_("nav.events")}</Link></li> -->
-          <!-- Postpone MakeWhole release -->
-          <!--<li><MakeWholeLink /></li>-->
         </ul>
       </div>
     {/if}
-    <!-- {#if $isInit} -->
     <div class="uk-navbar-right">
       <ul class="uk-navbar-nav">
         <li>
@@ -57,6 +51,5 @@
         </li>
       </ul>
     </div>
-    <!-- {/if} -->
   </nav>
 </main>

--- a/src/components/wallet/AccountNote.svelte
+++ b/src/components/wallet/AccountNote.svelte
@@ -4,8 +4,6 @@
 
   export let signingAccount
 
-  $signingAccount.note && console.log('>>> signingAccount.note', $signingAccount.note)
-
   async function updateNote() {
     associateNoteWithAccount($signingAccount.account, $signingAccount.note)
   }

--- a/src/components/wallet/AccountSwitcher.svelte
+++ b/src/components/wallet/AccountSwitcher.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
-  import { Link } from 'svelte-navigator'
+  import { Link, navigate } from 'svelte-navigator'
 
   import { signingAccount, allAccounts } from '../../modules/accounts'
   import { setAccount } from '../../modules/accountActions'
@@ -34,13 +34,16 @@
           {#if !$allAccounts}
             <p>loading...</p>
           {:else}
-            {#each $allAccounts as acc}
+            {#each $allAccounts.slice().sort((a, b) => a.nickname.localeCompare(b.nickname)) as acc}
               <li>
                 <a
                   href={'#'}
                   class={$signingAccount.account == acc.account ? 'uk-text-primary' : ''}
                   on:click={() => {
                     if ($signingAccount.account != acc.account) {
+                      if (acc.watch_only) {
+                        navigate('wallet')
+                      }
                       setAccount(acc.account)
                     }
                   }}

--- a/src/components/wallet/AccountsList.svelte
+++ b/src/components/wallet/AccountsList.svelte
@@ -212,7 +212,9 @@
     </table>
   {/if}
   <div style="display: {showOptions ? 'block' : 'none'};">
-    <Actions {signingAccount} />
+    {#if $signingAccount}
+      <Actions {signingAccount} />
+    {/if}
   </div>
 </main>
 

--- a/src/modules/accountActions.ts
+++ b/src/modules/accountActions.ts
@@ -187,9 +187,11 @@ export function findOneAccount(account: string): CarpeProfile | undefined {
 export const setAccount = async (account: string, notifySucess = true) => {
   if (get(signingAccount).account == account) return
 
+  const watchList = get(watchAccounts)
   invoke('switch_profile', { account })
     .then((res: CarpeProfile) => {
       res.account = res.account.toLocaleUpperCase()
+      res.watch_only = watchList.includes(res.account.toLocaleLowerCase())
       signingAccount.set(res)
       isInit.set(true)
       if (notifySucess) {
@@ -312,23 +314,6 @@ export const ignoreMigrate = () => {
     .then(isLegacy) // reset if we actually did migrate the files
     .catch((e: CarpeError) => raise_error(e, true, 'ignore_migrate'))
 }
-/*
-export let invoke_makewhole = async (account: String): Promise<number> => {
- // let demo_account = "613b6d9599f72134a4fa20bba4c75c36";
- // account = demo_account;
-
-  console.log(">>> calling make whole");
-  return await invoke("query_makewhole", { account })
-    .then((a) => {
-      if (a.length > 0) {
-        console.log("MakeWhole " + account + ", coins: " + a[0].coins.value)
-        console.log(a)
-      }
-      console.log(a);
-      return a[0].coins.value
-    })
-}
-*/
 
 export const updateMakeWhole = () => {
   const mk = get(makeWhole)


### PR DESCRIPTION
This pull request addresses two key enhancements:

1. **Disable Watch-Only Accounts from Accessing the Transfer Screen:** Users with watch-only accounts are now prevented from accessing the transfer screen. Additionally, if a user is on the transfer screen and selects a watch-only account from the dropdown menu, the wallet will automatically redirect them to the account list tab. This change enhances security and improves user experience by ensuring users do not remain on a screen they cannot interact with. Reported on https://github.com/0LNetworkCommunity/carpe/issues/286.

2. **Sort Accounts in Dropdown:** The accounts listed in the dropdown menu are now sorted alphabetically by their nicknames, improving the usability and organization of the account selection process.