### PR TITLE
Fixes set slow wallet modal and improve its texts

### DIFF
--- a/src/components/txs/SetWalletType.svelte
+++ b/src/components/txs/SetWalletType.svelte
@@ -9,11 +9,20 @@
   export let signingAccount;
   let loading = false;
   let isSlowWallet = false;
+  let confirmationModal
+
+  onMount(() => {
+    confirmationModal = UIkit.modal('#set-slow-wallet-confirmation-modal')
+  })
 
   const checkIsSlowWallet = async () => {
     if (signingAccount && signingAccount.account) {
       isSlowWallet = await is_slow_wallet(signingAccount.account);
     }
+  };
+
+  const openSlowModal = () => {
+    confirmationModal && confirmationModal.show();
   };
 
   const setWallet = (wtype: WalletType) => {
@@ -22,8 +31,8 @@
       .finally(() => {
         loading = false;
         checkIsSlowWallet(); // Recheck the slow wallet status after setting the wallet type
+        confirmationModal.hide();
       });
-    UIkit.modal('.wallet-modal').hide();
   };
 
   // Run checkIsSlowWallet when the component mounts
@@ -57,8 +66,8 @@
               <button
                 class="uk-button uk-button-default"
                 type="button"
-                uk-toggle="target: #slow"
                 disabled={loading ? true : false}
+                on:click|preventDefault={openSlowModal}
               >
                 {$_('txs.set_wallet_type.btn_slow')} ...
               </button>
@@ -74,14 +83,36 @@
     </ul>
 
     <!-- SLOW WALLET MODAL -->
-    <div id="slow" uk-modal class="uk-modal-container wallet-modal uk-text-center">
+    <div id="set-slow-wallet-confirmation-modal" uk-modal class="uk-modal-container">
       <div class="uk-modal-dialog uk-modal-body uk-padding-large">
-        <h4 class="uk-modal-title uk-text-uppercase uk-text-muted">
-          {$_('txs.set_wallet_type.warning')}
-        </h4>
-        <button class="uk-button uk-button-danger" on:click={() => setWallet(WalletType.Slow)}>
-          {$_('txs.set_wallet_type.btn_confirm_slow')}
-        </button>
+        <div>
+          <h2 class="uk-modal-title uk-text-uppercase uk-text-danger">
+            {$_('txs.set_wallet_type.modal.title')}
+          </h2>
+          <h3 class="uk-text-bold">{$_("txs.set_wallet_type.modal.body.question")}</h3>
+          <code class="uk-text-light">{$signingAccount.account}</code>
+          <p class="uk-text-lead uk-text-warning">{$_("txs.set_wallet_type.modal.body.review_list.title")}</p>
+          <ul class="uk-list uk-list-bullet uk-text-left uk-margin-top uk-margin-large-bottom">
+            <li>{@html $_("txs.set_wallet_type.modal.body.review_list.item1")}</li>
+            <li>{@html $_("txs.set_wallet_type.modal.body.review_list.item2")}</li>
+            <li>{@html $_("txs.set_wallet_type.modal.body.review_list.item3")}</li>
+          </ul>
+        </div>        
+        <div class="uk-margin-top uk-text-right">
+          <button 
+            class="uk-button uk-button-default uk-margin-right uk-modal-close"
+            disabled={loading}
+          >
+          {$_("txs.set_wallet_type.modal.btn_cancel")}
+          </button>
+          <button 
+            class="uk-button uk-button-danger" 
+            disabled={loading}
+            on:click={() => setWallet(WalletType.Slow)}
+          >
+            {$_('txs.set_wallet_type.modal.btn_confirm')}
+          </button>
+        </div>
       </div>
     </div>
   {/if}

--- a/src/lang/locales/ar.json
+++ b/src/lang/locales/ar.json
@@ -306,13 +306,20 @@
       "set_slow_title": "Make Slow Wallet (danger)",
       "subtitle": "Be sure you know what you are doing. This is not reversible. Slow and Community wallets are permanent.",
       "btn_slow": "Set Slow Wallet",
-      "btn_confirm_slow": "Confirm Set Slow Wallet? This is not reversible",
-      "warning": "Warning: this change is forever",
-      "btn_community": "Set Community Wallet",
-      "btn_confirm_community": "Set Community",
-      "community_confirm": "Confirm Set Community Wallet? This is not reversible",
-      "title": "Set your Account Type",
-      "slow_confirm": "Set Slow"
+      "modal": {
+        "title": "Warning: this change is forever",
+        "body": {
+          "question": "Are you sure you want to set this account as a slow wallet?",
+          "review_list": {
+            "title": "Please review the following before proceeding:",
+            "item1": "This operation is not reversible. After setting your wallet to slow you can't change it back.",
+            "item2": "This action will set the wallet to slow on the blockchain and will change your account liquidity.",
+            "item3": "Slow wallets have a daily unlock limit of 35,000 coins from the account balance."
+          }
+        },
+        "btn_confirm": "Confirm Set Slow Wallet? This is not reversible",
+        "btn_cancel": "Cancel"
+      }
     },
     "transfer": {
       "title": "Coin Transfer",

--- a/src/lang/locales/de.json
+++ b/src/lang/locales/de.json
@@ -302,17 +302,29 @@
       "no_balance_body2": "Sieht so aus, als hättest du weniger als 2 Coins auf deinem Konto, das bedeutet, dass du niemanden onboarden kannst."
     },
     "set_wallet_type": {
-      "actions_title": "Konto-Aktionen",
-      "set_slow_title": "Slow Wallet machen (Gefahr)",
-      "subtitle": " Es ist wichtig, dass du weißt, was du tust. Dies kann nicht mehr rückgängig gemacht werden. Slow und Community Wallets sind unveränderlich.",
-      "btn_slow": "Slow Wallet Wählen",
-      "btn_confirm_slow": "Slow Wallet bestätigen? Dies kann nicht rückgängig gemacht werden.",
-      "warning": "Warnung: Diese Änderung ist für immer",
-      "btn_community": "Community Wallet Wählen",
-      "btn_confirm_community": "Community Wählen",
-      "community_confirm": "Community Wallet bestätigen? Dies kann nicht rückgängig gemacht werden.",
-      "title": "Kontotyp Auswählen",
-      "slow_confirm": "Slow Wählen"
+      "actions_title": "Kontohandlungen",
+      "set_slow_title": "Langsame Wallet erstellen (gefährlich)",
+      "subtitle": "Stellen Sie sicher, dass Sie wissen, was Sie tun. Dies ist nicht umkehrbar. Langsame und Community-Wallets sind dauerhaft.",
+      "btn_slow": "Langsame Wallet setzen",
+      "modal": {
+        "title": "Warnung: Diese Änderung ist für immer",
+        "body": {
+          "question": "Sind Sie sicher, dass Sie dieses Konto als langsame Wallet festlegen möchten?",
+          "review_list": {
+            "title": "Bitte überprüfen Sie die folgenden Punkte, bevor Sie fortfahren:",
+            "item1": "Dieser Vorgang ist nicht umkehrbar. Nachdem Sie Ihre Wallet auf langsam gesetzt haben, können Sie dies nicht mehr ändern.",
+            "item2": "Diese Aktion wird die Wallet auf der Blockchain als langsam festlegen und Ihre Kontoliquidität ändern.",
+            "item3": "Langsame Wallets haben ein tägliches Freischaltungslimit von 35.000 Münzen vom Kontostand."
+          }
+        },
+        "btn_confirm": "Bestätigen Sie das Setzen der langsamen Wallet? Dies ist nicht umkehrbar",
+        "btn_cancel": "Abbrechen"
+      },
+      "btn_community": "Community Wallet setzen",
+      "btn_confirm_community": "Community setzen",
+      "community_confirm": "Bestätigen Sie das Setzen der Community Wallet? Dies ist nicht umkehrbar",
+      "title": "Legen Sie Ihren Kontotyp fest",
+      "slow_confirm": "Langsam setzen"
     },
     "transfer": {
       "title": "Überweisung von Coins",

--- a/src/lang/locales/en.json
+++ b/src/lang/locales/en.json
@@ -306,8 +306,20 @@
       "set_slow_title": "Make Slow Wallet (danger)",
       "subtitle": "Be sure you know what you are doing. This is not reversible. Slow and Community wallets are permanent.",
       "btn_slow": "Set Slow Wallet",
-      "btn_confirm_slow": "Confirm Set Slow Wallet? This is not reversible",
-      "warning": "Warning: this change is forever",
+      "modal": {
+        "title": "Warning: this change is forever",
+        "body": {
+          "question": "Are you sure you want to set this account as a slow wallet?",
+          "review_list": {
+            "title": "Please review the following before proceeding:",
+            "item1": "This operation is not reversible. After setting your wallet to slow you can't change it back.",
+            "item2": "This action will set the wallet to slow on the blockchain and will change your account liquidity.",
+            "item3": "Slow wallets have a daily unlock limit of 35,000 coins from the account balance."
+          }
+        },
+        "btn_confirm": "Confirm Set Slow Wallet? This is not reversible",
+        "btn_cancel": "Cancel"
+      },
       "btn_community": "Set Community Wallet",
       "btn_confirm_community": "Set Community",
       "community_confirm": "Confirm Set Community Wallet? This is not reversible",

--- a/src/lang/locales/es.json
+++ b/src/lang/locales/es.json
@@ -306,13 +306,20 @@
       "set_slow_title": "Make Slow Wallet (danger)",
       "subtitle": "Be sure you know what you are doing. This is not reversible. Slow and Community wallets are permanent.",
       "btn_slow": "Set Slow Wallet",
-      "btn_confirm_slow": "Confirm Set Slow Wallet? This is not reversible",
-      "warning": "Warning: this change is forever",
-      "btn_community": "Set Community Wallet",
-      "btn_confirm_community": "Set Community",
-      "community_confirm": "Confirm Set Community Wallet? This is not reversible",
-      "title": "Set your Account Type",
-      "slow_confirm": "Set Slow"
+      "modal": {
+        "title": "Warning: this change is forever",
+        "body": {
+          "question": "Are you sure you want to set this account as a slow wallet?",
+          "review_list": {
+            "title": "Please review the following before proceeding:",
+            "item1": "This operation is not reversible. After setting your wallet to slow you can't change it back.",
+            "item2": "This action will set the wallet to slow on the blockchain and will change your account liquidity.",
+            "item3": "Slow wallets have a daily unlock limit of 35,000 coins from the account balance."
+          }
+        },
+        "btn_confirm": "Confirm Set Slow Wallet? This is not reversible",
+        "btn_cancel": "Cancel"
+      }
     },
     "transfer": {
       "title": "Coin Transfer",

--- a/src/lang/locales/fr.json
+++ b/src/lang/locales/fr.json
@@ -302,17 +302,29 @@
       "no_balance_body2": "Vous avez moins de deux Coins sur votre compte, vous ne pouvez donc pas onboarder d'autres comptes."
     },
     "set_wallet_type": {
-      "actions_title": "Actions sur le compte",
-      "set_slow_title": "Faire du portefeuille lent (danger)",
-      "subtitle": " Soyez sûr de vous, cette opération est irreversible! Les portefeuilles \"Slow\" et \"Community\" sont permanents.",
-      "btn_slow": "Changer en \"Slow\"",
-      "btn_confirm_slow": "Confirmez le passage en \"Slow\"? Cet opération est irreversible.",
-      "warning": "Avertissement : ce changement est définitif",
-      "btn_community": "Changer en \"Community\"",
-      "btn_confirm_community": "Changer en \"Community\"",
-      "community_confirm": "Confirmez le passage en \"Community\"? Cet opération est irreversible",
-      "title": "Modifier le type de compte",
-      "slow_confirm": "Changer en \"Slow\""
+      "actions_title": "Actions du compte",
+      "set_slow_title": "Rendre le portefeuille lent (dangereux)",
+      "subtitle": "Assurez-vous de savoir ce que vous faites. Ce n'est pas réversible. Les portefeuilles lents et communautaires sont permanents.",
+      "btn_slow": "Définir le portefeuille lent",
+      "modal": {
+        "title": "Attention : ce changement est définitif",
+        "body": {
+          "question": "Êtes-vous sûr de vouloir définir ce compte comme un portefeuille lent?",
+          "review_list": {
+            "title": "Veuillez examiner les points suivants avant de continuer:",
+            "item1": "Cette opération est irréversible. Après avoir défini votre portefeuille sur lent, vous ne pouvez plus revenir en arrière.",
+            "item2": "Cette action définira le portefeuille comme lent sur la blockchain et modifiera la liquidité de votre compte.",
+            "item3": "Les portefeuilles lents ont une limite de déblocage quotidienne de 35 000 pièces du solde du compte."
+          }
+        },
+        "btn_confirm": "Confirmer le portefeuille lent? Ce n'est pas réversible",
+        "btn_cancel": "Annuler"
+      },
+      "btn_community": "Définir le portefeuille communautaire",
+      "btn_confirm_community": "Définir la communauté",
+      "community_confirm": "Confirmer le portefeuille communautaire? Ce n'est pas réversible",
+      "title": "Définissez votre type de compte",
+      "slow_confirm": "Définir lent"
     },
     "transfer": {
       "title": "Transfert de Coins",

--- a/src/lang/locales/it.json
+++ b/src/lang/locales/it.json
@@ -302,17 +302,29 @@
       "no_balance_body2": "Looks like you have less than 2 coins in your account, this means you won't be able to onboard anyone."
     },
     "set_wallet_type": {
-      "actions_title": "Account Actions",
-      "set_slow_title": "Make Slow Wallet (danger)",
-      "subtitle": " Make sure you know what you are doing. This is not reversible. Slow and Community wallets are permanent.",
-      "btn_slow": "Set Slow Wallet",
-      "btn_confirm_slow": "Confirm Set Slow Wallet? This is not reversable.",
-      "warning": "Warning: this change is forever",
-      "btn_community": "Set Community Wallet",
-      "btn_confirm_community": "Set Community",
-      "community_confirm": "Confirm Set Community Wallet? This is not reversable.",
-      "title": "Set your Account Type",
-      "slow_confirm": "Set Slow"
+      "actions_title": "Azioni dell'account",
+      "set_slow_title": "Rendere il portafoglio lento (pericoloso)",
+      "subtitle": "Assicurati di sapere cosa stai facendo. Questo non è reversibile. I portafogli lenti e comunitari sono permanenti.",
+      "btn_slow": "Imposta portafoglio lento",
+      "modal": {
+        "title": "Avviso: questa modifica è permanente",
+        "body": {
+          "question": "Sei sicuro di voler impostare questo account come portafoglio lento?",
+          "review_list": {
+            "title": "Si prega di rivedere quanto segue prima di procedere:",
+            "item1": "Questa operazione non è reversibile. Dopo aver impostato il portafoglio su lento, non è possibile tornare indietro.",
+            "item2": "Questa azione imposterà il portafoglio come lento sulla blockchain e cambierà la liquidità del tuo account.",
+            "item3": "I portafogli lenti hanno un limite di sblocco giornaliero di 35.000 monete dal saldo del conto."
+          }
+        },
+        "btn_confirm": "Confermare l'impostazione del portafoglio lento? Questo non è reversibile",
+        "btn_cancel": "Annulla"
+      },
+      "btn_community": "Imposta portafoglio comunitario",
+      "btn_confirm_community": "Imposta comunità",
+      "community_confirm": "Confermare l'impostazione del portafoglio comunitario? Questo non è reversibile",
+      "title": "Imposta il tipo di account",
+      "slow_confirm": "Imposta lento"
     },
     "transfer": {
       "title": "Coin Transfer",

--- a/src/lang/locales/pt.json
+++ b/src/lang/locales/pt.json
@@ -285,17 +285,29 @@
       "no_balance_body2": "Parece que você tem menos de 2 moedas em sua conta, isso significa que você não poderá embarcar ninguém."
     },
     "set_wallet_type": {
-      "actions_title": "Acções da conta",
-      "set_slow_title": "Fazer carteira lenta (perigo)",
-      "subtitle": "Certifique-se de que você sabe o que está fazendo. Essa operação não é reversível. As carteiras lentas e comunitárias são permanentes.",
+      "actions_title": "Ações da Conta",
+      "set_slow_title": "Tornar Carteira Lenta (perigoso)",
+      "subtitle": "Certifique-se de que você sabe o que está fazendo. Isso não é reversível. Carteiras Lentas e Comunitárias são permanentes.",
       "btn_slow": "Definir Carteira Lenta",
-      "btn_confirm_slow": "Confirmar Definir Carteira Lenta? Esta operação não é reversível.",
-      "warning": "Aviso: esta mudança é para sempre",
-      "btn_community": "Definir Carteira de Comunidade",
+      "modal": {
+        "title": "Aviso: esta alteração é permanente",
+        "body": {
+          "question": "Tem certeza de que deseja definir esta conta como uma carteira lenta?",
+          "review_list": {
+            "title": "Revise o seguinte antes de prosseguir:",
+            "item1": "Esta operação não é reversível. Depois de definir sua carteira como lenta, você não poderá alterar de volta.",
+            "item2": "Esta ação definirá a carteira como lenta na blockchain e mudará a liquidez da sua conta.",
+            "item3": "Carteiras lentas têm um limite diário de desbloqueio de 35.000 moedas do saldo da conta."
+          }
+        },
+        "btn_confirm": "Confirmar definição de Carteira Lenta? Isso não é reversível",
+        "btn_cancel": "Cancelar"
+      },
+      "btn_community": "Definir Carteira Comunitária",
       "btn_confirm_community": "Definir Comunidade",
-      "community_confirm": "Confirmar Definir Carteira de Comunidade? Esta operação não é reversível.",
-      "title": "Defina seu Tipo de Conta",
-      "slow_confirm": "Definir Lenta"
+      "community_confirm": "Confirmar definição de Carteira Comunitária? Isso não é reversível",
+      "title": "Defina o Tipo da Sua Conta",
+      "slow_confirm": "Definir Lento"
     },
     "transfer": {
       "title": "Transferência de Moedas",

--- a/src/lang/locales/zh_cn.json
+++ b/src/lang/locales/zh_cn.json
@@ -303,15 +303,27 @@
     },
     "set_wallet_type": {
       "actions_title": "账户操作",
-      "set_slow_title": "慢速钱包（危险）",
-      "subtitle": "确认您务必确认本次操作. 本操作不可逆. 慢钱包和社区钱包是永久性的。",
+      "set_slow_title": "设为慢钱包（危险）",
+      "subtitle": "确保你知道自己在做什么。这是不可逆的。慢钱包和社区钱包是永久性的。",
       "btn_slow": "设为慢钱包",
-      "btn_confirm_slow": "确认设置慢钱包吗？本操作不可逆。",
-      "warning": "警告：这一改变将是永久性的",
+      "modal": {
+        "title": "警告：此更改是永久性的",
+        "body": {
+          "question": "你确定要将此账户设为慢钱包吗？",
+          "review_list": {
+            "title": "在继续之前请检查以下内容：",
+            "item1": "此操作不可逆。将钱包设为慢钱包后，无法更改回去。",
+            "item2": "此操作将在区块链上将钱包设为慢钱包，并将改变你的账户流动性。",
+            "item3": "慢钱包每天的解锁限额为35,000枚硬币。"
+          }
+        },
+        "btn_confirm": "确认设为慢钱包？这不可逆",
+        "btn_cancel": "取消"
+      },
       "btn_community": "设为社区钱包",
-      "btn_confirm_community": "设为社区钱包",
-      "community_confirm": "确认要设为社区钱包吗？本操作不可逆。",
-      "title": "设置账户类型",
+      "btn_confirm_community": "设为社区",
+      "community_confirm": "确认设为社区钱包？这不可逆",
+      "title": "设置你的账户类型",
       "slow_confirm": "设为慢钱包"
     },
     "transfer": {


### PR DESCRIPTION
This PR fixes the issue with the "Set Slow Wallet" functionality, which stopped working correctly after being opened for the second time. Additionally, this PR enhances the warning message for the "Set Slow Wallet" operation to better inform users of the associated risks.

![image](https://github.com/0LNetworkCommunity/carpe/assets/10797037/21ce383e-9245-4dab-8f32-6b01031616d4)
