### PR TITLE
[autoupdater] publish manifest for v1.1.0 upgrade

### DIFF
--- a/autoupdater/autoupdater_payload.json
+++ b/autoupdater/autoupdater_payload.json
@@ -1,19 +1,19 @@
 {
-  "version": "1.0.11",
-  "notes": "bugfixes & feature to tag accounts",
-  "pub_date": "2024-03-11T10:57:15.333Z",
+  "version": "1.1.0",
+  "notes": "Compatibility with OL v8. Includes re-join tx and vouch transactions.",
+  "pub_date": "2025-06-18T00:39:38.540Z",
   "platforms": {
     "linux-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSb2t0YlhzSHBEbHNrbzZHMjdBNTJiZ2hJWU0xOWhiejRPU2lTZlIxKytnVnp2S01VUWNraXQyalhkY05lTzJSRzgvcit3NkJyNC80SGJkc0dscko3aklialcrYmFRblEwPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzE2ODE1MDQ5CWZpbGU6Y2FycGVfMS4wLjExX2FtZDY0LkFwcEltYWdlLnRhci5negp6R1VIY1lkaGo2dGhQK2grd1c1N2gySzNjK0VoOVc5WHVqMFg4K3hqdytCNjByTDBEVUFtdEU1Nnl6a3ozczZvUmFnZG96NWdrRTQwRUV3UkU5YnpCdz09Cg==",
-      "url": "https://github.com/0LNetworkCommunity/carpe/releases/download/v1.0.11/carpe_1.0.11_amd64.AppImage.tar.gz"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSb2t0YlhzSHBEbHNpN3VRNDBhSGpoLzJhTGZRK2EwK2I2QnI2U1ZoNlc4VEEwUVlldUhwZS8xSDFUUGlXSGN5WVF0TGovNnpIWG9yajZ0Q3M2cjdISTdrZ2pNclRnRlFJPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzUwMjA0MTIxCWZpbGU6Y2FycGVfMS4xLjBfYW1kNjQuQXBwSW1hZ2UudGFyLmd6CjJnYjRNcDkxRGhxZlRSZGs2RFhUUiszdnlPdGVpUldpN0NvaHR6OUozQlhsZVpmSXlIcVBmbHFtYmNYeXNpcEtxYTZTSTNqUVV5d3Q1VVhrSzVMakFBPT0K",
+      "url": "https://github.com/0LNetworkCommunity/carpe/releases/download/v1.1.0/carpe_1.1.0_amd64.AppImage.tar.gz"
     },
     "windows-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSb2t0YlhzSHBEbHVqdHQvWmkvRkQzbmF3cmwwMk5RcGxHcTRmUDdiTTFBRTl4YzVNTnZ0L0lLVDNkNVJmcXBKK3dkR0w3Zzd4QUx0V0poSDFHM29ydHN0L3JWd0k2ZFFBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzE2ODE1NTYxCWZpbGU6Y2FycGVfMS4wLjExX3g2NF9lbi1VUy5tc2kuemlwClUzNXlqUm1lQlBMSlEwcCs3ZnIvRjJXczJqclppYXBoY3hCOUdub0NLcStSYjE4N2F5MC9xUGpZeXhkNjk4WUVKb2RSbkhTWE9nL3pDTkJoT0dBZEFnPT0K",
-      "url": "https://github.com/0LNetworkCommunity/carpe/releases/download/v1.0.11/carpe_1.0.11_x64_en-US.msi.zip"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSb2t0YlhzSHBEbHZrbHdHZ0dURlIvWjUzOWRKUWlPSGRGMjdNYTZPVW5SdHlBcVdpVFprSEhodmplaEtaZk9LVm14bC9pMFRBYmJrd00xMWgraFk4ZG1UaDFMMnBtaXdJPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzUwMjA0Mjk4CWZpbGU6Y2FycGVfMS4xLjBfeDY0X2VuLVVTLm1zaS56aXAKNGpPTTBCK1VrL0NLSXY3a3BCREd2RDNpamZabXVXL3BVRkdTa2RBdld6KzhRTnY3OFFQNGlqTGdWTWZranY0MGp1RkNXaTRVOVcxUDRmWWJiUFp2RFE9PQo=",
+      "url": "https://github.com/0LNetworkCommunity/carpe/releases/download/v1.1.0/carpe_1.1.0_x64_en-US.msi.zip"
     },
     "darwin-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSb2t0YlhzSHBEbGcwNmlMMkVrQXJJSHFkSndhL2x4S1lqQ0NBNGx5OHNGMnM4OGR1ajZ1YzQxMEs5dUNxZHkwTzM0bWw3M09Dbms5NFVPQnNGTkhZZnF3Q2VzNnRHS1FRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzE2ODE3NTY1CWZpbGU6Y2FycGUuYXBwLnRhci5negpOOGdKeExUUzhmNjR6YzZZR0VHVm95cWFIaDJtcmo4UDl5TFRtMGxSQ1l2aTNNMGhsQ1d6d0Q4a2pnc1ZldGxOQUpsZXdwL1V5TXQ3Zlhick9GUzNCQT09Cg==",
-      "url": "https://github.com/0LNetworkCommunity/carpe/releases/download/v1.0.11/carpe_x64.app.tar.gz"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSb2t0YlhzSHBEbHVob1l3bEUvazBkUWdqc25PYXExQzBzb3pmclhpSUZkeTJjQm5PVHpncGtaMmt4TzdmMzlzU1gzeWd3MFJ3NkwxbWpNWmF4L0hlMjNSaWhqYmhRVlE4PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzUwMjA3MTcyCWZpbGU6Y2FycGUuYXBwLnRhci5negpYMElMblRkT1BjallxV1loUi9RUGJjVmxiOGNQUCtrdlZaMHk0RDZNVHlKUUZJbTJTeXZscVBaR1ZjYkpESjlRM0lEbGN3N00yekJ4blNlM1FRckZEUT09Cg==",
+      "url": "https://github.com/0LNetworkCommunity/carpe/releases/download/v1.1.0/carpe_x64.app.tar.gz"
     }
   }
 }


### PR DESCRIPTION
Carpe installations that start after this PR is merged will be prompted to begin the autoupdate with the v1.1.0 payloads.