### PR TITLE
[profile] remove legacy account option

### DIFF
--- a/src-tauri/src/commands/networks.rs
+++ b/src-tauri/src/commands/networks.rs
@@ -17,6 +17,7 @@ pub async fn toggle_network(chain_id_str: &str) -> Result<NetworkPlaylist, Carpe
   let chain_id = NamedChain::from_str(chain_id_str)?;
   let mut app_cfg = CONFIG_MUTEX.lock().await;
   app_cfg.set_chain_id(chain_id);
+  // TODO: save_file might be duplicated with `maybe_create_playlist`
   app_cfg.save_file()?;
   maybe_create_playlist(&mut app_cfg, chain_id).await.ok();
 

--- a/src-tauri/src/commands/networks.rs
+++ b/src-tauri/src/commands/networks.rs
@@ -17,8 +17,7 @@ pub async fn toggle_network(chain_id_str: &str) -> Result<NetworkPlaylist, Carpe
   let chain_id = NamedChain::from_str(chain_id_str)?;
   let mut app_cfg = CONFIG_MUTEX.lock().await;
   app_cfg.set_chain_id(chain_id);
-  // TODO: save_file might be duplicated with `maybe_create_playlist`
-  app_cfg.save_file()?;
+  // Save file is handled within `maybe_create_playlist`
   maybe_create_playlist(&mut app_cfg, chain_id).await.ok();
 
   get_networks().await

--- a/src-tauri/src/commands/wallets.rs
+++ b/src-tauri/src/commands/wallets.rs
@@ -243,9 +243,10 @@ pub fn get_default_profile() -> Result<CarpeProfile, CarpeError> {
 pub async fn refresh_accounts() -> Result<Vec<CarpeProfile>, CarpeError> {
   let mut app_cfg = CONFIG_MUTEX.lock().await;
 
-  // while we are here check if the accounts are on chain
-  // under a different address than implied by authkey
-  map_get_originating_address(&mut app_cfg.user_profiles).await?;
+  // NOTE: map_get_originating_address was reverting the profile account
+  // after someone made a manual override on it.
+
+  // map_get_originating_address(&mut app_cfg.user_profiles).await?;
   map_get_balance(&mut app_cfg.user_profiles).await?;
   app_cfg.save_file()?;
 

--- a/src-tauri/src/commands/wallets.rs
+++ b/src-tauri/src/commands/wallets.rs
@@ -289,6 +289,7 @@ async fn map_get_balance(list: &mut [Profile]) -> anyhow::Result<(), CarpeError>
   futures::future::join_all(list.iter_mut().map(|e| async {
     if let Ok(b) = query::get_balance(e.account).await {
       e.balance = b;
+      e.on_chain = true;
     }
   }))
   .await;

--- a/src-tauri/src/commands/wallets.rs
+++ b/src-tauri/src/commands/wallets.rs
@@ -538,7 +538,7 @@ pub async fn override_account_address(
   auth_key: AuthenticationKey,
 ) -> Result<CarpeProfile, CarpeError> {
   let mut app_cfg = get_cfg()?;
-  
+
   // Find the profile with the matching old address and auth key
   let profile = app_cfg
     .user_profiles
@@ -549,14 +549,14 @@ pub async fn override_account_address(
   // Update the account address for this profile
   profile.account = new_address;
   profile.nickname = get_short(new_address);
-  
+
   // Save the configuration
   app_cfg.save_file()?;
-  
+
   // Convert to CarpeProfile and assign notes
   let mut carpe_profile: CarpeProfile = profile.into();
   let mut profiles = vec![carpe_profile];
   assign_notes_to_accounts(&mut profiles)?;
-  
+
   Ok(profiles.into_iter().next().unwrap())
 }

--- a/src-tauri/src/commands/wallets.rs
+++ b/src-tauri/src/commands/wallets.rs
@@ -245,7 +245,8 @@ pub async fn refresh_accounts() -> Result<Vec<CarpeProfile>, CarpeError> {
 
   // NOTE: map_get_originating_address was reverting the profile account
   // after someone made a manual override on it.
-
+  // This function is currently disabled but might be needed in the future
+  // for handling profile account overrides. See Issue #123 for details.
   // map_get_originating_address(&mut app_cfg.user_profiles).await?;
   map_get_balance(&mut app_cfg.user_profiles).await?;
   app_cfg.save_file()?;

--- a/src-tauri/src/commands/wallets.rs
+++ b/src-tauri/src/commands/wallets.rs
@@ -528,3 +528,35 @@ pub fn remove_legacy_account(authkey: AuthenticationKey) -> Result<String, Carpe
     Err(CarpeError::misc("account not found"))
   }
 }
+
+/// Override the account address for a given auth key
+/// This is needed for legacy migration issues where one authkey might link to two addresses onchain
+#[tauri::command(async)]
+pub async fn override_account_address(
+  old_address: AccountAddress,
+  new_address: AccountAddress,
+  auth_key: AuthenticationKey,
+) -> Result<CarpeProfile, CarpeError> {
+  let mut app_cfg = get_cfg()?;
+  
+  // Find the profile with the matching old address and auth key
+  let profile = app_cfg
+    .user_profiles
+    .iter_mut()
+    .find(|p| p.account == old_address && p.auth_key == auth_key)
+    .ok_or_else(|| CarpeError::misc("Profile with matching address and auth key not found"))?;
+
+  // Update the account address for this profile
+  profile.account = new_address;
+  profile.nickname = get_short(new_address);
+  
+  // Save the configuration
+  app_cfg.save_file()?;
+  
+  // Convert to CarpeProfile and assign notes
+  let mut carpe_profile: CarpeProfile = profile.into();
+  let mut profiles = vec![carpe_profile];
+  assign_notes_to_accounts(&mut profiles)?;
+  
+  Ok(profiles.into_iter().next().unwrap())
+}

--- a/src-tauri/src/commands/wallets.rs
+++ b/src-tauri/src/commands/wallets.rs
@@ -102,9 +102,7 @@ pub async fn init_from_mnem(mnem: String) -> Result<CarpeProfile, CarpeError> {
 }
 
 #[tauri::command(async)]
-pub async fn init_from_private_key(
-  pri_key_string: String,
-) -> Result<CarpeProfile, CarpeError> {
+pub async fn init_from_private_key(pri_key_string: String) -> Result<CarpeProfile, CarpeError> {
   let pri = Ed25519PrivateKey::from_encoded_string(&pri_key_string)
     .map_err(|_| anyhow!("cannot parse encoded private key"))?;
   let acc_struct = account_keys::get_account_from_private(&pri);
@@ -112,22 +110,21 @@ pub async fn init_from_private_key(
     Ok(p) => p,
     Err(_e) => {
       // the account may not exist on chain so we'll default to the derived address
-      add_account_by_authkey(acc_struct.auth_key, Some(acc_struct.account))
-        .await?
+      add_account_by_authkey(acc_struct.auth_key, Some(acc_struct.account)).await?
     }
   };
 
-
   key_manager::set_private_key(&core_profile.account, acc_struct.pri_key)
     .map_err(|e| CarpeError::config(&e.to_string()))?;
-
 
   Ok(core_profile)
 }
 
 // add the account to profile by authkey
-pub async fn add_account_by_authkey(authkey: AuthenticationKey, force_address: Option<AccountAddress>) -> Result<CarpeProfile, CarpeError> {
-
+pub async fn add_account_by_authkey(
+  authkey: AuthenticationKey,
+  force_address: Option<AccountAddress>,
+) -> Result<CarpeProfile, CarpeError> {
   // IMPORTANT
   // let's check if this account has had a rotated authkey,
   // so the address we derive may not be the expected one.
@@ -432,9 +429,7 @@ pub fn get_private_key_from_os(address: AccountAddress) -> Result<String, CarpeE
 }
 
 #[tauri::command(async)]
-pub async fn add_watch_account(
-  address: AccountAddress,
-) -> Result<CarpeProfile, CarpeError> {
+pub async fn add_watch_account(address: AccountAddress) -> Result<CarpeProfile, CarpeError> {
   // Catch edge case the user is setting up a carpe for the first time
   // only with a watch account.
   if !configs::is_initialized() {

--- a/src-tauri/src/commands/wallets.rs
+++ b/src-tauri/src/commands/wallets.rs
@@ -17,10 +17,10 @@ use libra_types::{
 };
 use libra_wallet::account_keys::{self, KeyChain};
 use serde::{Deserialize, Serialize};
-use std::{fs::OpenOptions, str::FromStr};
 use std::fs::{self, File};
 use std::io::{prelude::*, Write};
 use std::path::{Path, PathBuf};
+use std::{fs::OpenOptions, str::FromStr};
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct NewKeygen {
@@ -534,14 +534,14 @@ pub async fn override_account_address(
   auth_key_str: &str,
 ) -> Result<(), CarpeError> {
   // Clean up the auth_key_str - remove 0x/0X prefix if present and ensure lowercase
-    let lower_auth_key = auth_key_str.trim().to_lowercase();
-    let clean_auth_key = lower_auth_key.trim_start_matches("0x");
-   // Convert the cleaned auth_key string to AuthenticationKey
-    let auth_key = AuthenticationKey::from_str(clean_auth_key)
-        .map_err(|e| CarpeError::misc(&format!("Invalid auth key format: {}", e)))?;
-    
-    // Use CONFIG_MUTEX to ensure thread safety and consistency
-    let mut app_cfg = CONFIG_MUTEX.lock().await;
+  let lower_auth_key = auth_key_str.trim().to_lowercase();
+  let clean_auth_key = lower_auth_key.trim_start_matches("0x");
+  // Convert the cleaned auth_key string to AuthenticationKey
+  let auth_key = AuthenticationKey::from_str(clean_auth_key)
+    .map_err(|e| CarpeError::misc(&format!("Invalid auth key format: {}", e)))?;
+
+  // Use CONFIG_MUTEX to ensure thread safety and consistency
+  let mut app_cfg = CONFIG_MUTEX.lock().await;
 
   // Find the profile with the matching old address and auth key
   let profile = app_cfg
@@ -555,10 +555,9 @@ pub async fn override_account_address(
 
   // Update the account address for this profile
   profile.account = new_address;
-  
+
   // Set this account as the default one in the workspace
   app_cfg.workspace.set_default(nickname);
-  
 
   // Save the configuration
   app_cfg.save_file()?;

--- a/src-tauri/src/commands/wallets.rs
+++ b/src-tauri/src/commands/wallets.rs
@@ -445,7 +445,8 @@ pub async fn add_watch_account(
 
   configs_profile::set_account_profile(address, authkey).await?;
 
-  Ok(Profile::new(authkey, address))
+  let profile = &Profile::new(authkey, address);
+  Ok(profile.into())
 }
 
 fn read_legacy_accounts() -> Result<LegacyAccounts, Error> {
@@ -536,7 +537,7 @@ pub async fn override_account_address(
   old_address: AccountAddress,
   new_address: AccountAddress,
   auth_key: AuthenticationKey,
-) -> Result<CarpeProfile, CarpeError> {
+) -> Result<(), CarpeError> {
   let mut app_cfg = get_cfg()?;
 
   // Find the profile with the matching old address and auth key
@@ -548,15 +549,9 @@ pub async fn override_account_address(
 
   // Update the account address for this profile
   profile.account = new_address;
-  profile.nickname = get_short(new_address);
 
   // Save the configuration
   app_cfg.save_file()?;
 
-  // Convert to CarpeProfile and assign notes
-  let mut carpe_profile: CarpeProfile = profile.into();
-  let mut profiles = vec![carpe_profile];
-  assign_notes_to_accounts(&mut profiles)?;
-
-  Ok(profiles.into_iter().next().unwrap())
+  Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -97,6 +97,7 @@ async fn main() {
       commands::wallets::init_from_private_key,
       commands::wallets::remove_accounts,
       commands::wallets::remove_account,
+      commands::wallets::override_account_address,
       commands::wallets::switch_profile,
       commands::wallets::is_slow,
       commands::wallets::set_slow_wallet,

--- a/src/components/wallet/AccountDetails.svelte
+++ b/src/components/wallet/AccountDetails.svelte
@@ -4,6 +4,7 @@
   import AccountNote from './AccountNote.svelte';
   import SetWalletType from '../txs/SetWalletType.svelte';
   import GetPrivateKey from './GetPrivateKey.svelte';
+  import OverrideAddress from './OverrideAddress.svelte';
   import RemoveAccount from './RemoveAccount.svelte';
   import { _ } from 'svelte-i18n';
 
@@ -29,6 +30,9 @@
           {#if !$signingAccount.watch_only}
             <div class="uk-width-1-2@m">
               <GetPrivateKey />
+            </div>
+            <div class="uk-width-1-2@m">
+              <OverrideAddress {signingAccount} />
             </div>
           {/if}          
           <div class="uk-width-1-1">

--- a/src/components/wallet/AccountDetails.svelte
+++ b/src/components/wallet/AccountDetails.svelte
@@ -34,17 +34,17 @@
             <div class="uk-width-1-2@m">
               <OverrideAddress {signingAccount} />
             </div>
-          {/if}          
+          {/if}
           <div class="uk-width-1-1">
             <SetWalletType {signingAccount} />
-          </div>          
+          </div>
         </div>
         <div class="uk-margin-top uk-flex uk-flex-left uk-flex-wrap">
           <RemoveAccount {signingAccount} />
         </div>
       </div>
     </section>
-  {/if}  
+  {/if}
 </main>
 
 <style>

--- a/src/components/wallet/AccountFromMnemForm.svelte
+++ b/src/components/wallet/AccountFromMnemForm.svelte
@@ -4,11 +4,7 @@
   import { onDestroy } from 'svelte'
 
   let formDangerMnem: string
-  let isLegacy = false
-  function toggle() {
-    isLegacy = !isLegacy
-  }
-  
+
   onDestroy(() => (formDangerMnem = null))
 </script>
 
@@ -27,12 +23,7 @@
           bind:value={formDangerMnem}
         />
       </div>
-      <div class="uk-margin-bottom uk-inline-block uk-width-1-1">
-        <label
-          ><input class="uk-checkbox" type="checkbox" on:click={toggle} checked={isLegacy} />&nbsp; {$_('wallet.legacy_account_opt')}</label
-        >
-      </div>
-      <AccountFromMnemSubmit {formDangerMnem} isNewAccount={false} {isLegacy} />
+      <AccountFromMnemSubmit {formDangerMnem} isNewAccount={false} />
     </fieldset>
   </form>
 </main>

--- a/src/components/wallet/AccountFromMnemSubmit.svelte
+++ b/src/components/wallet/AccountFromMnemSubmit.svelte
@@ -7,7 +7,6 @@
 
   export let formDangerMnem: string
   export let isNewAccount = true
-  export let isLegacy = false;
 
   let confirmationModal
 
@@ -24,11 +23,11 @@
   }
 
   let isSubmitting = false
-  function initAccount(mnem_string: string, isLegacy) {
+  function initAccount(mnem_string: string) {
     if (mnem_string.length == 0) return
     mnem_string = mnem_string.trim().split(/\s+/).join(' ')
     isSubmitting = true
-    addAccount(InitType.Mnem, mnem_string.trim(), isLegacy).finally(() => {
+    addAccount(InitType.Mnem, mnem_string.trim()).finally(() => {
       isSubmitting = false
       mnem_string = null
       confirmationModal && confirmationModal.hide()
@@ -51,7 +50,7 @@
     class="uk-button uk-button-primary"
     type="button"
     disabled={isSubmitting}
-    on:click|preventDefault={initAccount(formDangerMnem, isLegacy)}
+    on:click|preventDefault={initAccount(formDangerMnem)}
   >
     {#if isSubmitting}
       {$_('wallet.account_from_mnem_submit.btn_submiting')}...
@@ -79,7 +78,7 @@
         class="uk-button uk-button-primary"
         type="button"
         disabled={isSubmitting}
-        on:click|preventDefault={initAccount(formDangerMnem, isLegacy)}
+        on:click|preventDefault={initAccount(formDangerMnem)}
       >
         {#if isSubmitting}
           {$_('wallet.account_from_mnem_submit.btn_submiting')}

--- a/src/components/wallet/AccountFromPrivateKey.svelte
+++ b/src/components/wallet/AccountFromPrivateKey.svelte
@@ -9,7 +9,7 @@
     isLegacy = !isLegacy
   }
   const initAccount = (pri_key: string) => {
-    addAccount(InitType.PriKey, pri_key.trim(), isLegacy).finally(() => {
+    addAccount(InitType.PriKey, pri_key.trim()).finally(() => {
       danger_temp_private_key = null
       navigate('wallet')
     })

--- a/src/components/wallet/OverrideAddress.svelte
+++ b/src/components/wallet/OverrideAddress.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+  import { invoke } from '@tauri-apps/api/tauri';
+  import { _ } from 'svelte-i18n';
+  import { notify_success, notify_error } from '../../modules/carpeNotify';
+  import { overrideAccountAddress } from '../../modules/accountActions';
+
+  export let signingAccount;
+  
+  let newAddress = '';
+  let loading = false;
+  let showConfirmation = false;
+  
+  const validateAddress = (address: string): boolean => {
+    // Basic validation - address should be 32 bytes hex (64 characters) with 0x prefix
+    const cleanAddress = address.startsWith('0x') ? address.slice(2) : address;
+    return /^[a-fA-F0-9]{64}$/.test(cleanAddress);
+  };
+
+  const formatAddress = (address: string): string => {
+    const cleanAddress = address.startsWith('0x') ? address.slice(2) : address;
+    return '0x' + cleanAddress.toLowerCase();
+  };
+
+  const handleOverrideAddress = async () => {
+    if (!newAddress.trim()) {
+      notify_error('Please enter a new address');
+      return;
+    }
+
+    if (!validateAddress(newAddress)) {
+      notify_error('Invalid address format. Address should be 64 hex characters.');
+      return;
+    }
+
+    const formattedAddress = formatAddress(newAddress);
+    
+    if (formattedAddress.toLowerCase() === signingAccount.account.toLowerCase()) {
+      notify_error('New address is the same as current address');
+      return;
+    }
+
+    showConfirmation = true;
+  };
+
+  const confirmOverride = async () => {
+    loading = true;
+    showConfirmation = false;
+
+    try {
+      const formattedAddress = formatAddress(newAddress);
+      
+      await overrideAccountAddress(
+        signingAccount.account, 
+        formattedAddress, 
+        signingAccount.auth_key
+      );
+      
+      newAddress = '';
+      
+    } catch (error) {
+      console.error('Error overriding address:', error);
+      // Error handling is done in the overrideAccountAddress function
+    } finally {
+      loading = false;
+    }
+  };
+
+  const cancelOverride = () => {
+    showConfirmation = false;
+  };
+
+  const clearInput = () => {
+    newAddress = '';
+  };
+</script>
+
+<main class="uk-card uk-card-default uk-card-body uk-height-1-1" style="height: 280px;">
+  <div class="uk-flex uk-flex-column uk-height-1-1">
+    <h5 class="uk-text-light uk-text-uppercase uk-text-muted uk-text-thin">
+      {$_('wallet.override_address.title')}
+    </h5>
+    <p style="margin:0px; margin-bottom: 10px;">
+      {$_('wallet.override_address.description')}
+    </p>
+    
+    <div class="uk-flex-1 uk-flex uk-flex-column">
+      <div class="uk-margin-small">
+        <div class="uk-text-small uk-text-muted">Current Address:</div>
+        <div class="uk-text-small uk-text-break">
+          <code>{signingAccount?.account || 'N/A'}</code>
+        </div>
+      </div>
+      
+      <div class="uk-margin-small">
+        <label for="new-address-input" class="uk-form-label uk-text-small uk-text-muted">New Address:</label>
+        <div class="uk-flex">
+          <input
+            id="new-address-input"
+            class="uk-input uk-form-small"
+            type="text"
+            placeholder="0x..."
+            bind:value={newAddress}
+            disabled={loading}
+            style="font-family: monospace; font-size: 12px;"
+          />
+          {#if newAddress}
+            <button
+              class="uk-button uk-button-link uk-margin-small-left"
+              on:click={clearInput}
+              disabled={loading}
+            >
+              ✕
+            </button>
+          {/if}
+        </div>
+      </div>
+    </div>
+    
+    <div class="uk-flex uk-flex-bottom uk-flex-right">
+      <button
+        class="uk-button uk-button-primary uk-button-small"
+        on:click={handleOverrideAddress}
+        disabled={loading || !newAddress.trim()}
+      >
+        {#if loading}
+          <div uk-spinner="ratio: 0.5"></div>
+        {:else}
+          {$_('wallet.override_address.button')}
+        {/if}
+      </button>
+    </div>
+  </div>
+</main>
+
+<!-- Confirmation Modal -->
+{#if showConfirmation}
+  <div class="uk-modal uk-open" style="display: block;">
+    <div class="uk-modal-dialog uk-modal-body">
+      <h2 class="uk-modal-title">Confirm Address Override</h2>
+      <p>Are you sure you want to override the address for this account?</p>
+      <p><strong>Current:</strong> <code>{signingAccount?.account}</code></p>
+      <p><strong>New:</strong> <code>{formatAddress(newAddress)}</code></p>
+      <p class="uk-text-warning">
+        <strong>Warning:</strong> This action will update the profile's address. Make sure the new address is correct.
+      </p>
+      <p class="uk-text-right">
+        <button class="uk-button uk-button-default uk-margin-small-right" on:click={cancelOverride}>
+          Cancel
+        </button>
+        <button class="uk-button uk-button-primary" on:click={confirmOverride} disabled={loading}>
+          {#if loading}
+            <div uk-spinner="ratio: 0.5"></div>
+          {:else}
+            Confirm Override
+          {/if}
+        </button>
+      </p>
+    </div>
+  </div>
+  <div class="uk-modal-backdrop uk-open"></div>
+{/if}
+
+<style>
+  .uk-modal-backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  
+  code {
+    word-break: break-all;
+    font-size: 11px;
+  }
+  
+  .uk-text-break {
+    word-break: break-all;
+  }
+</style>

--- a/src/components/wallet/OverrideAddress.svelte
+++ b/src/components/wallet/OverrideAddress.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/tauri';
   import { _ } from 'svelte-i18n';
-  import { notify_success, notify_error } from '../../modules/carpeNotify';
+  import { notify_error } from '../../modules/carpeNotify';
   import { overrideAccountAddress } from '../../modules/accountActions';
 
   export let signingAccount;
-  
+
   let newAddress = '';
   let loading = false;
   let showConfirmation = false;
-  
+
   const validateAddress = (address: string): boolean => {
     // Basic validation - address should be 32 bytes hex (64 characters) with 0x prefix
     const cleanAddress = address.startsWith('0x') ? address.slice(2) : address;
@@ -33,7 +32,7 @@
     }
 
     const formattedAddress = formatAddress(newAddress);
-    
+
     if (formattedAddress.toLowerCase() === signingAccount.account.toLowerCase()) {
       notify_error('New address is the same as current address');
       return;
@@ -48,15 +47,15 @@
 
     try {
       const formattedAddress = formatAddress(newAddress);
-      
+
       await overrideAccountAddress(
-        signingAccount.account, 
-        formattedAddress, 
+        signingAccount.account,
+        formattedAddress,
         signingAccount.auth_key
       );
-      
+
       newAddress = '';
-      
+
     } catch (error) {
       console.error('Error overriding address:', error);
       // Error handling is done in the overrideAccountAddress function
@@ -82,7 +81,7 @@
     <p style="margin:0px; margin-bottom: 10px;">
       {$_('wallet.override_address.description')}
     </p>
-    
+
     <div class="uk-flex-1 uk-flex uk-flex-column">
       <div class="uk-margin-small">
         <div class="uk-text-small uk-text-muted">Current Address:</div>
@@ -90,7 +89,7 @@
           <code>{signingAccount?.account || 'N/A'}</code>
         </div>
       </div>
-      
+
       <div class="uk-margin-small">
         <label for="new-address-input" class="uk-form-label uk-text-small uk-text-muted">New Address:</label>
         <div class="uk-flex">
@@ -115,7 +114,7 @@
         </div>
       </div>
     </div>
-    
+
     <div class="uk-flex uk-flex-bottom uk-flex-right">
       <button
         class="uk-button uk-button-primary uk-button-small"
@@ -164,12 +163,12 @@
   .uk-modal-backdrop {
     background: rgba(0, 0, 0, 0.5);
   }
-  
+
   code {
     word-break: break-all;
     font-size: 11px;
   }
-  
+
   .uk-text-break {
     word-break: break-all;
   }

--- a/src/lang/locales/en.json
+++ b/src/lang/locales/en.json
@@ -97,6 +97,11 @@
       "btn_hide": "Hide Private Key",
       "btn_get": "Get Private Key"
     },
+    "override_address": {
+      "title": "Override Address",
+      "description": "Override the account address due to legacy migration issues:",
+      "button": "Override Address"
+    },
     "keygen": {
       "title": "Create New Account",
       "description": "After you generate an account and secret phrase, you'll need someone to send one 0L coin to that account for it to be created on chain.",

--- a/src/lang/locales/es.json
+++ b/src/lang/locales/es.json
@@ -93,6 +93,11 @@
       "btn_hide": "Hide Private Key",
       "btn_get": "Get Private Key"
     },
+    "override_address": {
+      "title": "Anular Dirección",
+      "description": "Anular la dirección de la cuenta debido a problemas de migración heredados:",
+      "button": "Anular Dirección"
+    },
     "keygen": {
       "title": "Create New Account",
       "description": "After you generate an account and secret phrase, you'll need someone to send one 0L coin to that account for it to be created on chain.",

--- a/src/lang/locales/fr.json
+++ b/src/lang/locales/fr.json
@@ -93,6 +93,11 @@
       "btn_hide": "Masquer la Clé Privée",
       "btn_get": "Obtenir la Clé Privée"
     },
+    "override_address": {
+      "title": "Remplacer l'Adresse",
+      "description": "Remplacer l'adresse du compte en raison de problèmes de migration hérités:",
+      "button": "Remplacer l'Adresse"
+    },
     "keygen": {
       "title": "Creer un nouveau compte",
       "description": "Aprés avoir généré votre compte et phrase secrète, vous aurez besoin que quelqu'un envoie un Coin 0L à ce compte pour qu'il soit mis sur la chaîne.",

--- a/src/modules/accountActions.ts
+++ b/src/modules/accountActions.ts
@@ -145,10 +145,7 @@ const addAccountOptimistic = async (address: string, watch_only: boolean) => {
   allAccounts.set(list)
 }
 
-export const addAccount = async (
-  init_type: InitType,
-  secret: string
-) => {
+export const addAccount = async (init_type: InitType, secret: string) => {
   let method_name = ''
   let arg_obj = {}
   if (init_type == InitType.Mnem) {
@@ -559,12 +556,16 @@ export const associateNoteWithAccount = async (account, note) => {
   }
 }
 
-export const overrideAccountAddress = async (oldAddress: string, newAddress: string, authKey: string) => {
+export const overrideAccountAddress = async (
+  oldAddress: string,
+  newAddress: string,
+  authKey: string,
+) => {
   try {
-    const result = await invoke('override_account_address', { 
+    const result = await invoke('override_account_address', {
       oldAddress: oldAddress,
       newAddress: newAddress,
-      authKey: authKey
+      authKey: authKey,
     })
     await refreshAccounts()
     notify_success('Account address successfully overridden')

--- a/src/modules/accountActions.ts
+++ b/src/modules/accountActions.ts
@@ -555,4 +555,3 @@ export const associateNoteWithAccount = async (account, note) => {
     notify_error('Failed to associate note with account')
   }
 }
-

--- a/src/modules/accountActions.ts
+++ b/src/modules/accountActions.ts
@@ -556,23 +556,3 @@ export const associateNoteWithAccount = async (account, note) => {
   }
 }
 
-export const overrideAccountAddress = async (
-  oldAddress: string,
-  newAddress: string,
-  authKey: string,
-) => {
-  try {
-    const result = await invoke('override_account_address', {
-      oldAddress: oldAddress,
-      newAddress: newAddress,
-      authKey: authKey,
-    })
-    await refreshAccounts()
-    notify_success('Account address successfully overridden')
-    return result
-  } catch (e) {
-    raise_error(e, true, 'overrideAccountAddress')
-    notify_error('Failed to override account address')
-    throw e
-  }
-}

--- a/src/modules/accountActions.ts
+++ b/src/modules/accountActions.ts
@@ -147,38 +147,39 @@ const addAccountOptimistic = async (address: string, watch_only: boolean) => {
 
 export const addAccount = async (
   init_type: InitType,
-  secret: string,
-  isLegacy: boolean = false,
+  secret: string
 ) => {
   let method_name = ''
   let arg_obj = {}
   if (init_type == InitType.Mnem) {
     method_name = 'init_from_mnem'
-    arg_obj = { mnem: secret.trim(), isLegacy }
+    arg_obj = { mnem: secret.trim() }
   } else if (init_type == InitType.PriKey) {
     method_name = 'init_from_private_key'
-    arg_obj = { priKeyString: secret.trim(), isLegacy }
+    arg_obj = { priKeyString: secret.trim() }
   }
 
   addAccountOptimistic('loading...', false)
 
   // submit
   return invoke(method_name, arg_obj)
-    .then(async (res: CarpeProfile) => {
-      // update watchAccounts
-      let list = get(watchAccounts)
-      list = list.filter((item) => item !== res.account)
-      watchAccounts.set(list)
-      localStorage.setItem('watchAccounts', JSON.stringify(list))
-      res.watch_only = false
-
-      await onAccountAdd(res)
-      return res
-    })
+    .then(setWatchAccounts)
     .catch((error) => {
       raise_error(error, false, 'addAccount')
     })
     .finally(() => (secret = null))
+}
+
+const setWatchAccounts = async (res: CarpeProfile) => {
+  // update watchAccounts
+  let list = get(watchAccounts)
+  list = list.filter((item) => item !== res.account)
+  watchAccounts.set(list)
+  localStorage.setItem('watchAccounts', JSON.stringify(list))
+  res.watch_only = false
+
+  await onAccountAdd(res)
+  return res
 }
 
 export const removeAccount = async (account: string) => {

--- a/src/modules/accountActions.ts
+++ b/src/modules/accountActions.ts
@@ -558,3 +558,20 @@ export const associateNoteWithAccount = async (account, note) => {
     notify_error('Failed to associate note with account')
   }
 }
+
+export const overrideAccountAddress = async (oldAddress: string, newAddress: string, authKey: string) => {
+  try {
+    const result = await invoke('override_account_address', { 
+      oldAddress: oldAddress,
+      newAddress: newAddress,
+      authKey: authKey
+    })
+    await refreshAccounts()
+    notify_success('Account address successfully overridden')
+    return result
+  } catch (e) {
+    raise_error(e, true, 'overrideAccountAddress')
+    notify_error('Failed to override account address')
+    throw e
+  }
+}


### PR DESCRIPTION
Legacy account was a helper to smooth the migration from v5 to v6. This is no longer needed. However there is a broader edge case which needs to be solved: that the originatingAccountLookup will match more than one account address to a given authkey. In v5 it was possible that a person used the same mnemonic on two accounts. It's an extreme edgecase because the user would have to deliberately rotate the keys on accounts so that they would have the same key.
Effectively Carpe is unusable for people in this case. So we should add a component in AccountDetails, which allows the overriding of the account address in the Carpe profile.